### PR TITLE
Fix Smooth Zoom on World Hop + Updated build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,32 +1,71 @@
 plugins {
-	id 'java'
+    id 'java'
 }
 
 repositories {
-	mavenLocal()
-	maven {
-		url = 'https://repo.runelite.net'
-	}
-	mavenCentral()
+    mavenLocal()
+    maven {
+        url = 'https://repo.runelite.net'
+        content {
+            includeGroupByRegex("net\\.runelite.*")
+        }
+    }
+    mavenCentral()
 }
 
-def runeLiteVersion = '1.8.25'
+def runeLiteVersion = 'latest.release'
+def pluginMainClass = 'com.camerasmoothing.CameraSmoothingTest'
+//  CHANGE this if your PluginTest class name differs
 
 dependencies {
-	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
+    compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
 
-	compileOnly 'org.projectlombok:lombok:1.18.20'
-	annotationProcessor 'org.projectlombok:lombok:1.18.20'
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
 
-	testImplementation 'junit:junit:4.12'
-	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
-	testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
+    testImplementation 'junit:junit:4.12'
+    testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
+    testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
 }
 
 group = 'com.camerasmoothing'
-version = '1.2'
-sourceCompatibility = '1.8'
+version = '1.2-SNAPSHOT'
 
-tasks.withType(JavaCompile) {
-	options.encoding = 'UTF-8'
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+    options.release.set(11)
+}
+
+tasks.register('run', JavaExec) {
+    classpath = sourceSets.test.runtimeClasspath
+    mainClass = pluginMainClass
+
+    jvmArgs "-ea"
+    args "--developer-mode", "--debug"
+}
+
+tasks.register('shadowJar', Jar) {
+    dependsOn configurations.testRuntimeClasspath
+    manifest {
+        attributes('Main-Class': pluginMainClass, 'Multi-Release': true)
+    }
+
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    from sourceSets.main.output
+    from sourceSets.test.output
+    from {
+        configurations.testRuntimeClasspath.collect { file ->
+            file.isDirectory() ? file : zipTree(file)
+        }
+    }
+
+    exclude 'META-INF/INDEX.LIST'
+    exclude 'META-INF/*.SF'
+    exclude 'META-INF/*.DSA'
+    exclude 'META-INF/*.RSA'
+    exclude '**/module-info.class'
+
+    group = 'build'
+    archiveClassifier.set('shadow')
+    archiveFileName.set("${rootProject.name}-${project.version}-all.jar")
 }

--- a/src/main/java/com/camerasmoothing/CameraSmoothingPlugin.java
+++ b/src/main/java/com/camerasmoothing/CameraSmoothingPlugin.java
@@ -6,7 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import net.runelite.api.events.BeforeRender;
 import net.runelite.api.events.GameStateChanged;
-import net.runelite.api.events.ScriptCallbackEvent;
+import net.runelite.api.events.GameTick;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
@@ -14,118 +14,141 @@ import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 
-int bombo; //PAY NO ATTENTION : BOMBO
-
 @Slf4j
 @PluginDescriptor(
-	name = "Camera Smoothing"
+        name = "Camera Smoothing"
 )
 public class CameraSmoothingPlugin extends Plugin
 {
-	@Inject
-	private Client client;
+    @Inject
+    private Client client;
 
-	@Inject
-	private CameraSmoothingConfig config;
+    @Inject
+    private CameraSmoothingConfig config;
 
-	@Inject
-	private ClientThread clientThread;
+    @Inject
+    private ClientThread clientThread;
 
-	private final int HALF_ROTATION = 1024;
-	private final int FULL_ROTATION = 2048;
+    private final int HALF_ROTATION = 1024;
+    private final int FULL_ROTATION = 2048;
 
-	private final int PITCH_INDEX = 0;
-	private final int YAW_INDEX = 1;
-	private final int SCROLL_INDEX = 2;
-	//Made an array just in case a setter for camera pitch is ever added
-	private int[] deltaCamera = new int[3];
-	private int[] previousCamera = new int[3];
+    private final int PITCH_INDEX = 0;
+    private final int YAW_INDEX = 1;
+    private final int SCROLL_INDEX = 2;
+    //Made an array just in case a setter for camera pitch is ever added
+    private int[] deltaCamera = new int[3];
+    private int[] previousCamera = new int[3];
 
-	private int lerp(int x, int y, float alpha) {
-		return x+(int)((y-x)*alpha);
-	}
-	private int getSmallestAngle(int x, int y) {
-		return mod(((y-x) + HALF_ROTATION), FULL_ROTATION) - HALF_ROTATION;
-	}
-	//https://stackoverflow.com/questions/1878907/how-can-i-find-the-difference-between-two-angles
-	//This function was tested to produce results that were much more reasonable than the modulo operator
-	public int mod(int a, int n) {
-		return (int)(a - Math.floor(a/(float)n) * n);
-	}
-	private void applySmoothingToAngle(int index) {
-		int deltaChange;
-		int changed;
-		int newDeltaAngle;
-		newDeltaAngle = getSmallestAngle(previousCamera[index],index == YAW_INDEX ? client.getMapAngle() : 0/*No pitch method in RL*/);
-		deltaCamera[index] += newDeltaAngle;
+    // Added for smooth zoom after world hop
+    private boolean zoomReady = false;
 
-		deltaChange = lerp(deltaCamera[index],0,(config.smoothness()/100.0f));
-		changed = previousCamera[index] + deltaChange;
+    private int lerp(int x, int y, float alpha) {
+        return x+(int)((y-x)*alpha);
+    }
+    private int getSmallestAngle(int x, int y) {
+        return mod(((y-x) + HALF_ROTATION), FULL_ROTATION) - HALF_ROTATION;
+    }
+    //https://stackoverflow.com/questions/1878907/how-can-i-find-the-difference-between-two-angles
+    //This function was tested to produce results that were much more reasonable than the modulo operator
+    public int mod(int a, int n) {
+        return (int)(a - Math.floor(a/(float)n) * n);
+    }
+    private void applySmoothingToAngle(int index) {
+        int deltaChange;
+        int changed;
+        int newDeltaAngle;
+        newDeltaAngle = getSmallestAngle(previousCamera[index],index == YAW_INDEX ? client.getMapAngle() : 0/*No pitch method in RL*/);
+        deltaCamera[index] += newDeltaAngle;
 
-		deltaCamera[index] -= deltaChange;
-		if(index == YAW_INDEX) {
-			client.setCameraYawTarget(changed);
-		}/* else if(index == PITCH_INDEX) {
+        deltaChange = lerp(deltaCamera[index],0,(config.smoothness()/100.0f));
+        changed = previousCamera[index] + deltaChange;
+
+        deltaCamera[index] -= deltaChange;
+        if(index == YAW_INDEX) {
+            client.setCameraYawTarget(changed);
+        }/* else if(index == PITCH_INDEX) {
 			//No pitch method in RL yet
 		}*/
-		previousCamera[index] += deltaChange;
-	}
-	private void setZoom(int amount) {
-		clientThread.invoke(()-> client.runScript(ScriptID.CAMERA_DO_ZOOM,amount,amount));
-	}
-	private void applySmoothingToZoom(int index) {
-		int deltaChange;
-		int changed;
-		int newZoom;
-		newZoom = client.getVarcIntValue(VarClientInt.CAMERA_ZOOM_RESIZABLE_VIEWPORT) - previousCamera[index];
-		deltaCamera[index] += newZoom;
+        previousCamera[index] += deltaChange;
+    }
+    private void setZoom(int amount) {
+        clientThread.invoke(()-> client.runScript(ScriptID.CAMERA_DO_ZOOM,amount,amount));
+    }
+    private void applySmoothingToZoom(int index) {
+        int deltaChange;
+        int changed;
+        int newZoom;
+        newZoom = client.getVarcIntValue(VarClientInt.CAMERA_ZOOM_RESIZABLE_VIEWPORT) - previousCamera[index];
+        deltaCamera[index] += newZoom;
 
-		deltaChange = lerp(deltaCamera[index],0,Math.max(0,Math.min(1,(config.smoothness()) / 100.0f)));
-		changed = previousCamera[index] + deltaChange;
+        deltaChange = lerp(deltaCamera[index],0,Math.max(0,Math.min(1,(config.smoothness()) / 100.0f)));
+        changed = previousCamera[index] + deltaChange;
 
-		deltaCamera[index] -= deltaChange;
-		if(index == SCROLL_INDEX) {
-			setZoom(changed);
-		}
-		previousCamera[index] += deltaChange;
-	}
-	@Subscribe
-	public void onConfigChanged(ConfigChanged ev) {
-		if(ev.getKey().equals("smoothRotation")) {
-			if(config.smoothRotation()) {
-				previousCamera[YAW_INDEX] = client.getMapAngle();
-			}
-		} else if(ev.getKey().equals("smoothZoom")) {
-			if(config.smoothZoom()) {
-				previousCamera[SCROLL_INDEX] = client.getVar(VarClientInt.CAMERA_ZOOM_RESIZABLE_VIEWPORT);
-			}
-		}
-	}
-	@Subscribe
-	public void onBeforeRender(BeforeRender render) {
-		if(client.getGameState() != GameState.LOGGED_IN) {
-			return;
-		}
-		int deltaChange;
-		int changed;
-		int newDeltaAngle;
+        deltaCamera[index] -= deltaChange;
+        if(index == SCROLL_INDEX) {
+            setZoom(changed);
+        }
+        previousCamera[index] += deltaChange;
+    }
+    @Subscribe
+    public void onConfigChanged(ConfigChanged ev) {
+        if(ev.getKey().equals("smoothRotation")) {
+            if(config.smoothRotation()) {
+                previousCamera[YAW_INDEX] = client.getMapAngle();
+            }
+        } else if(ev.getKey().equals("smoothZoom")) {
+            if(config.smoothZoom()) {
+                previousCamera[SCROLL_INDEX] = client.getVarcIntValue(VarClientInt.CAMERA_ZOOM_RESIZABLE_VIEWPORT);
+                zoomReady = true; // initialize zoomReady when smoothZoom toggled on
+            }
+        }
+    }
+    @Subscribe
+    public void onBeforeRender(BeforeRender render) {
+        if(client.getGameState() != GameState.LOGGED_IN) {
+            return;
+        }
+        int deltaChange;
+        int changed;
+        int newDeltaAngle;
 
-		if(config.smoothRotation()) {
-			//Pitch stuff to be added if runelite ever decides to add a Client.setCameraPitchTarget method
-			//Until then, yaw going to have to stick with yaw!
-			//applySmoothingToAngle(PITCH_INDEX);
-			applySmoothingToAngle(YAW_INDEX);
-		}
+        if(config.smoothRotation()) {
+            //Pitch stuff to be added if runelite ever decides to add a Client.setCameraPitchTarget method
+            //Until then, yaw going to have to stick with yaw!
+            //applySmoothingToAngle(PITCH_INDEX);
+            applySmoothingToAngle(YAW_INDEX);
+        }
 
-		if(config.smoothZoom()) {
-			applySmoothingToZoom(SCROLL_INDEX);
-		}
+        if(config.smoothZoom() && zoomReady) { // only smooth if zoomReady
+            applySmoothingToZoom(SCROLL_INDEX);
+        }
 
-	}
+    }
 
-	@Provides
-	CameraSmoothingConfig provideConfig(ConfigManager configManager)
-	{
-		return configManager.getConfig(CameraSmoothingConfig.class);
-	}
+    // New addition: sync zoom after world hop
+    @Subscribe
+    public void onGameTick(GameTick event) {
+        if(!zoomReady && client.getGameState() == GameState.LOGGED_IN) {
+            int zoom = client.getVarcIntValue(VarClientInt.CAMERA_ZOOM_RESIZABLE_VIEWPORT);
+            if(zoom > 0) {
+                previousCamera[SCROLL_INDEX] = zoom;
+                deltaCamera[SCROLL_INDEX] = 0;
+                zoomReady = true;
+            }
+        }
+    }
+
+    // New addition: reset zoomReady on login
+    @Subscribe
+    public void onGameStateChanged(GameStateChanged event) {
+        if(event.getGameState() == GameState.LOGGED_IN) {
+            zoomReady = false;
+        }
+    }
+
+    @Provides
+    CameraSmoothingConfig provideConfig(ConfigManager configManager)
+    {
+        return configManager.getConfig(CameraSmoothingConfig.class);
+    }
 }

--- a/src/test/java/com/camerasmoothing/CameraSmoothingTest.java
+++ b/src/test/java/com/camerasmoothing/CameraSmoothingTest.java
@@ -5,9 +5,9 @@ import net.runelite.client.externalplugins.ExternalPluginManager;
 
 public class CameraSmoothingTest
 {
-	public static void main(String[] args) throws Exception
-	{
-		ExternalPluginManager.loadBuiltin(CameraSmoothingPlugin.class);
-		RuneLite.main(args);
-	}
+    public static void main(String[] args) throws Exception
+    {
+        ExternalPluginManager.loadBuiltin(CameraSmoothingPlugin.class);
+        RuneLite.main(args);
+    }
 }


### PR DESCRIPTION
**Summary:**
This PR fixes the issue where smooth zoom would jump or zoom out unexpectedly after a world hop. The underlying problem was that the plugin’s smoothing logic was reading transitional or uninitialized zoom values immediately after login or world hop, causing the camera to interpolate from an invalid state.

**Changes Made (Minimal and Focused):**

 - Added a boolean field **zoomReady** to track when the zoom value is initialized and safe to smooth.
- Added a `@Subscribe public void onGameTick(GameTick event)` method to safely initialize **previousCamera[SCROLL_INDEX]** after logging in or world hopping.
- Added a guard in **onBeforeRender** to only apply smooth zoom when **zoomReady** is true.
- Updated **onConfigChanged** and **onGameStateChanged** to reset or initialize **zoomReady** appropriately.

**Important Notes:**

   - No **other logic** in the plugin was changed. The smoothing math (**lerp**, **deltaCamera**, etc.) remains identical.
 
 **Testing Performed:**
 
   -  Smooth zoom now initializes correctly after world hop.
   - Smooth rotation remains unaffected.
   - Toggling smooth zoom on/off works without breaking the previous zoom state.
   - No jumps or unexpected zoom behavior occurs on login.